### PR TITLE
Replace IP-based firewall with tinyproxy domain filtering

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ ENV TZ=${TZ} \
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git curl ca-certificates sudo make \
         zsh nano vim less jq \
-        iptables ipset iproute2 dnsutils \
+        iptables tinyproxy iproute2 dnsutils \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
@@ -41,7 +41,9 @@ RUN pip install --no-cache-dir \
     ruff>=0.4 \
     mypy>=1.10
 
-# Firewall script
+# Forward proxy config (tinyproxy) and firewall script
+COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+COPY allowlist.conf /etc/tinyproxy/allowlist
 COPY init-firewall.sh /usr/local/bin/init-firewall.sh
 RUN chmod +x /usr/local/bin/init-firewall.sh
 

--- a/.devcontainer/allowlist.conf
+++ b/.devcontainer/allowlist.conf
@@ -1,0 +1,38 @@
+# Outbound domain allowlist for tinyproxy.
+# One POSIX basic regex per line. Lines starting with # are comments.
+#
+# How to add a domain at runtime (no rebuild needed):
+#   1. Edit /etc/tinyproxy/allowlist inside the container
+#   2. sudo kill -HUP $(pidof tinyproxy)
+#
+# To persist for future builds, also edit .devcontainer/allowlist.conf
+# in the repo.
+#
+# Patterns are POSIX basic regex (not plain domain names).
+#    '.' means "any character" — use \. for a literal dot.
+#    Always anchor with ^ and $: ^exact\.domain\.com$
+#    An unanchored 'github.com' would also match 'evil-github.com'.
+
+# -- Anthropic — Claude Code API, web app, docs, telemetry ------------
+^api\.anthropic\.com$
+^claude\.ai$
+^code\.claude\.com$
+^statsig\.anthropic\.com$
+# Sentry — error reporting.  Bare domain plus structured ingest
+# subdomain pattern, kept tight to limit exfiltration surface.
+^sentry\.io$
+^o[0-9]+\.ingest\.[a-z]+\.sentry\.io$
+
+# -- GitHub — git push/pull, API, CLI package repo --------------------
+# Note: githubusercontent.com deliberately excluded (serves arbitrary
+# user content). If a gh command fails needing it, add it back knowingly.
+^github\.com$
+^api\.github\.com$
+^cli\.github\.com$
+
+# -- npm — Claude Code is installed via npm ---------------------------
+^registry\.npmjs\.org$
+
+# -- PyPI — pip install for Python dev deps ----------------------------
+^pypi\.org$
+^files\.pythonhosted\.org$

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,13 @@
   ],
   "containerEnv": {
     "PYTHONDONTWRITEBYTECODE": "1",
-    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "http_proxy": "http://127.0.0.1:3128",
+    "https_proxy": "http://127.0.0.1:3128",
+    "HTTP_PROXY": "http://127.0.0.1:3128",
+    "HTTPS_PROXY": "http://127.0.0.1:3128",
+    "no_proxy": "localhost,127.0.0.1,127.0.0.11,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+    "NO_PROXY": "localhost,127.0.0.1,127.0.0.11,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -2,42 +2,29 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# ── Outbound allowlist ──────────────────────────────────────────────────
-# Only these domains can be reached from inside the container.
-# Edit this list to add/remove access. DNS resolution happens at
-# container start, so changes require a restart.
+# -- Forward proxy firewall (fail-closed) ---------------------------------
+# Applies iptables default-deny FIRST, then starts tinyproxy.
+# If tinyproxy fails to start, the container remains locked down
+# (only DNS, SSH, and loopback work) rather than being wide open.
 #
-# Why allowlist?  This container may run with --dangerously-skip-permissions,
-# meaning Claude Code can execute arbitrary commands without prompting.
-# The firewall is the compensating control — even if code tries to
-# exfiltrate data, it can only reach these destinations.
+# Domain allowlist:  /etc/tinyproxy/allowlist
+# Proxy config:      /etc/tinyproxy/tinyproxy.conf
+#
+# To add a domain at runtime (no restart needed):
+#   1. Edit /etc/tinyproxy/allowlist
+#   2. sudo kill -HUP $(pidof tinyproxy)
 
-ALLOWED_DOMAINS=(
-    # Anthropic — Claude Code API, docs, and telemetry
-    "api.anthropic.com"
-    "claude.ai"
-    "code.claude.com"
-    "statsig.anthropic.com"
-    "sentry.io"
+# -- Stop existing tinyproxy if running (handles re-runs) -----------------
 
-    # GitHub — git push/pull, API, and CLI package repo
-    # Note: githubusercontent.com deliberately excluded (serves arbitrary
-    # user content). If a gh command fails needing it, add it back knowingly.
-    "github.com"
-    "api.github.com"
-    "cli.github.com"
+if pidof tinyproxy > /dev/null 2>&1; then
+    echo "Stopping existing tinyproxy..."
+    kill "$(pidof tinyproxy)" 2>/dev/null || true
+    sleep 1
+fi
 
-    # npm — Claude Code is installed via npm
-    "registry.npmjs.org"
+# -- iptables setup -------------------------------------------------------
 
-    # PyPI — pip install for Python dev deps
-    "pypi.org"
-    "files.pythonhosted.org"
-)
-
-# ── Firewall setup ──────────────────────────────────────────────────────
-
-# Preserve Docker's internal DNS rules before flushing
+# Preserve Docker's internal DNS NAT rules before flushing
 DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
 
 # Clean slate
@@ -47,9 +34,8 @@ iptables -t nat -F
 iptables -t nat -X
 iptables -t mangle -F
 iptables -t mangle -X
-ipset destroy allowed-domains 2>/dev/null || true
 
-# Restore Docker DNS (containers need this to resolve service names)
+# Restore Docker DNS (containers need 127.0.0.11 for service name resolution)
 if [ -n "$DOCKER_DNS_RULES" ]; then
     iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
     iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
@@ -58,15 +44,31 @@ if [ -n "$DOCKER_DNS_RULES" ]; then
     done <<< "$DOCKER_DNS_RULES"
 fi
 
-# Always allow: DNS queries, localhost, SSH
-iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
-iptables -A INPUT -p udp --sport 53 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
-iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+# -- Default deny (applied BEFORE proxy starts = fail-closed) -------------
+
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# -- Always allowed: loopback, established, DNS, SSH, host network --------
+
+# Loopback (apps connect to local proxy on 127.0.0.1:3128 via this)
 iptables -A INPUT -i lo -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT
 
-# Allow host network (needed for Docker<->host communication)
+# Established/related connections (early in chain for performance)
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# DNS (UDP 53 — needed for tinyproxy to resolve allowed domains)
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+
+# SSH
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+
+# Host network (Docker gateway — needed for Docker<->host communication)
 HOST_IP=$(ip route | grep default | cut -d" " -f3)
 if [ -n "$HOST_IP" ]; then
     HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
@@ -74,43 +76,53 @@ if [ -n "$HOST_IP" ]; then
     iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
 fi
 
-# Resolve allowed domains to IPs and build the ipset
-ipset create allowed-domains hash:net
-echo "Resolving ${#ALLOWED_DOMAINS[@]} allowed domains..."
+# -- Proxy enforcement ----------------------------------------------------
+# Only the tinyproxy user can make outbound HTTP/HTTPS connections.
+# Everyone else must go through the proxy (via env vars).
 
-for domain in "${ALLOWED_DOMAINS[@]}"; do
-    # Use +short to avoid CNAME chain column-position issues
-    ips=$(dig +short A "$domain" 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$')
-    if [ -n "$ips" ]; then
-        count=0
-        while IFS= read -r ip; do
-            ipset add allowed-domains "$ip" 2>/dev/null || true
-            count=$((count + 1))
-        done <<< "$ips"
-        echo "  $domain -> $count IPs"
-    else
-        echo "  $domain -> FAILED to resolve (will be blocked)"
-    fi
-done
+TINYPROXY_UID=$(id -u tinyproxy)
+iptables -A OUTPUT -m owner --uid-owner "$TINYPROXY_UID" -p tcp --dport 443 -j ACCEPT
+iptables -A OUTPUT -m owner --uid-owner "$TINYPROXY_UID" -p tcp --dport 80 -j ACCEPT
 
-# Default policy: drop everything, then poke holes
-iptables -P INPUT DROP
-iptables -P FORWARD DROP
-iptables -P OUTPUT DROP
-
-# Allow responses to connections we initiated
-iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-# Allow outbound only to whitelisted IPs
-iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
-
-# Reject (not drop) everything else — gives immediate feedback instead of timeout
+# Reject (not drop) unmatched outbound — gives immediate error feedback
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
+echo "iptables applied (default-deny). Starting proxy..."
+
+# -- Start tinyproxy -------------------------------------------------------
+
+# Create PID directory (on tmpfs, lost between container restarts)
+mkdir -p /run/tinyproxy
+chown tinyproxy:tinyproxy /run/tinyproxy
+
+# Start proxy (daemonizes into background)
+tinyproxy -c /etc/tinyproxy/tinyproxy.conf
+
+# Verify it started
+sleep 1
+if ! pidof tinyproxy > /dev/null 2>&1; then
+    echo "ERROR: tinyproxy failed to start. Check /var/log/tinyproxy/tinyproxy.log"
+    echo "Firewall IS active (fail-closed). Only DNS, SSH, and loopback work."
+    echo "Fix the proxy config, then re-run this script."
+    exit 1
+fi
+
+echo "Forward proxy started on 127.0.0.1:3128"
+
+# -- Summary ---------------------------------------------------------------
+
+DOMAIN_COUNT=$(grep -cve '^\s*#' -e '^\s*$' /etc/tinyproxy/allowlist)
 echo ""
-echo "Firewall active. Outbound restricted to:"
-printf '  - %s\n' "${ALLOWED_DOMAINS[@]}"
+echo "Firewall active. Outbound HTTP/HTTPS filtered by forward proxy."
+echo "  Proxy:    http://127.0.0.1:3128"
+echo "  Domains:  ${DOMAIN_COUNT} patterns in /etc/tinyproxy/allowlist"
+echo "  Log:      /var/log/tinyproxy/tinyproxy.log"
 echo ""
-echo "To test: 'curl https://example.com' should fail immediately."
-echo "         'curl https://api.anthropic.com' should succeed."
+echo "To test:"
+echo "  curl -x http://127.0.0.1:3128 https://api.anthropic.com  → should succeed"
+echo "  curl -x http://127.0.0.1:3128 https://example.com        → should fail (403)"
+echo "  curl https://example.com                                  → should fail (REJECT)"
+echo ""
+echo "To add a domain at runtime:"
+echo "  1. sudo nano /etc/tinyproxy/allowlist"
+echo "  2. sudo kill -HUP \$(pidof tinyproxy)"

--- a/.devcontainer/tinyproxy.conf
+++ b/.devcontainer/tinyproxy.conf
@@ -1,0 +1,40 @@
+# tinyproxy configuration for dev container outbound filtering.
+# See: https://tinyproxy.github.io/
+
+# Run as the tinyproxy system user (created by apt package)
+User tinyproxy
+Group tinyproxy
+
+# Listen on localhost only — apps connect via proxy env vars
+Port 3128
+Listen 127.0.0.1
+
+# Connection limits
+Timeout 600
+MaxClients 100
+
+# Only accept connections from inside this container
+Allow 127.0.0.1/8
+Allow ::1
+
+# -- Domain filtering (whitelist mode) ---------------------------------
+# FilterDefaultDeny Yes = deny everything EXCEPT matching patterns.
+# FilterURLs Off       = match against hostname only (not full URL).
+# Filter file uses POSIX basic regex, case-insensitive by default.
+Filter "/etc/tinyproxy/allowlist"
+FilterDefaultDeny Yes
+FilterURLs Off
+FilterCaseSensitive Off
+
+# Only allow CONNECT (HTTPS tunneling) to port 443
+ConnectPort 443
+
+# Logging — Connect level logs connection events without per-request noise
+LogFile "/var/log/tinyproxy/tinyproxy.log"
+LogLevel Connect
+
+# Don't reveal proxy presence to upstream servers
+DisableViaHeader Yes
+
+# PID file for signal-based management (SIGHUP reload, etc.)
+PidFile "/run/tinyproxy/tinyproxy.pid"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ If you find a security vulnerability, please report it responsibly. Key areas to
 - **Volume mounts:** `resolve_volume()` validates paths within allowed directories
 - **CORS:** Configured via `CORS_ORIGINS` environment variable (default: localhost only)
 - **Network:** Nginx binds to `127.0.0.1` by default — LAN access is opt-in
-- **Dev container firewall:** Outbound traffic restricted to allowlisted domains only — see `.devcontainer/init-firewall.sh`
+- **Dev container firewall:** Outbound HTTP/HTTPS is routed through a tinyproxy forward proxy that filters by domain name. iptables blocks direct outbound from all users except the proxy. See `.devcontainer/allowlist.conf` for the domain list and `.devcontainer/init-firewall.sh` for the setup. To add a domain at runtime: edit `/etc/tinyproxy/allowlist` and `sudo kill -HUP $(pidof tinyproxy)`.
 - **GH_TOKEN:** Forwarded into the container for git push — use a fine-grained PAT scoped to this repo with Contents read/write only
 
 ## Code Style

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,7 +27,13 @@ services:
     environment:
       - PYTHONDONTWRITEBYTECODE=1
       - GH_TOKEN=${GH_TOKEN:-}
-    command: sleep infinity
+      - http_proxy=http://127.0.0.1:3128
+      - https_proxy=http://127.0.0.1:3128
+      - HTTP_PROXY=http://127.0.0.1:3128
+      - HTTPS_PROXY=http://127.0.0.1:3128
+      - no_proxy=localhost,127.0.0.1,127.0.0.11,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+      - NO_PROXY=localhost,127.0.0.1,127.0.0.11,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    command: bash -c "sudo /usr/local/bin/init-firewall.sh && exec sleep infinity"
     ## Uncomment to skip firewall (faster startup, less secure):
     # entrypoint: ""
 


### PR DESCRIPTION
The old firewall resolved domains to IPs at startup via dig, which went stale as CDNs rotated addresses. Replace iptables+ipset with a tinyproxy forward proxy that filters outbound HTTPS by hostname at the CONNECT handshake. iptables now only enforces that traffic goes through the proxy (fail-closed: default-deny is applied before tinyproxy starts).

Closes #20

  ---
  Test plan

  After rebuilding the container (Rebuild Container in VS Code, or docker compose -f docker-compose.dev.yml build && up -d):

  - Firewall starts cleanly
  sudo /usr/local/bin/init-firewall.sh
  # Should print "Forward proxy started" and "Firewall active"
  - Allowed domain works through proxy
  curl -s -o /dev/null -w "%{http_code}" -x http://127.0.0.1:3128 https://api.anthropic.com
  # Any HTTP response (200, 401, 403) means connection succeeded
  - Blocked domain rejected by proxy
  curl -x http://127.0.0.1:3128 https://example.com
  # Expected: HTTP 403 from tinyproxy
  - Direct connection (bypassing proxy) blocked by iptables
  curl --noproxy '*' https://api.anthropic.com
  # Expected: immediate REJECT (even allowed domains can't bypass proxy)
  - Tools work through proxy env vars
  pip install --dry-run requests                                     # pypi.org
  npm view @anthropic-ai/claude-code version                         # registry.npmjs.org
  git ls-remote https://github.com/grinnellian/wickerman-os.git HEAD # github.com
  gh api rate_limit --jq '.rate.remaining'                           # api.github.com
  - Claude Code works
  claude --version
  - Runtime domain addition (no restart)
  curl -x http://127.0.0.1:3128 https://example.com                 # should fail
  echo '^example\.com$' | sudo tee -a /etc/tinyproxy/allowlist
  sudo kill -HUP $(pidof tinyproxy)
  curl -x http://127.0.0.1:3128 https://example.com                 # should succeed
  sudo sed -i '/^example/d' /etc/tinyproxy/allowlist                 # clean up
  sudo kill -HUP $(pidof tinyproxy)
  - DNS and SSH still work
  dig github.com +short
  ssh -T git@github.com 2>&1 | head -1
  - Optional: test NET_RAW removal — remove --cap-add=NET_RAW from devcontainer.json and NET_RAW from docker-compose.dev.yml, rebuild, and run sudo /usr/local/bin/init-firewall.sh. If it succeeds, commit the removal; if Permission
  denied, add it back.

  ---
  All of these run inside the container. The workflow is:

  1. Rebuild the container (this is the only step outside — VS Code "Rebuild Container" or docker compose build && up -d)
  2. Shell in and run the checklist top to bottom
  3. If anything fails, fix and rebuild again

  The postStartCommand in devcontainer.json runs init-firewall.sh automatically, so for the VS Code path the firewall should already be active when you open a terminal. For docker-compose, the new command handles it. Step 1 in the
  checklist is mainly a sanity check / re-run test.